### PR TITLE
Annotate @event and @handler decorators to preserve decorated functio…

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Configuration
 > for this event.  
 
 ```python
-
 from amqp_events.celery import events_app
 
 app = events_app(
@@ -41,6 +40,7 @@ Adding events and handlers
 --------------------------
 
 ```python
+from demo.celery import app
 
 @app.event('service_name.object_name.event_name')
 def even_number_generated(number: int):
@@ -74,9 +74,10 @@ Sending events
 
 ```python
 import random
+from demo.events import number_is_even
 
 try:
-    even_number_generated(random.randint(0, 100))
+    number_is_even(random.randint(0, 100))
 except ValueError:
     print("oops, number was odd")
 ```

--- a/amqp_events/events.py
+++ b/amqp_events/events.py
@@ -1,5 +1,5 @@
-from functools import partial
-from typing import Callable, Any, Set, TypeVar, Tuple, Type, Dict
+from typing import Callable, Any, Set, TypeVar, Tuple, Type, Protocol
+from typing import cast
 
 from celery import Celery, Task
 from celery.canvas import Signature
@@ -8,9 +8,30 @@ from kombu import Exchange, Queue
 
 from amqp_events import tasks, defaults
 
-T = TypeVar('T')
+AnyFunc = Callable[..., Any]
+F = TypeVar('F')
+# noinspection PyTypeChecker
+T = TypeVar('T', bound=AnyFunc)
 
 
+class EventProtocol(Protocol[T]):
+    """
+    EventProtocol describes a function signature that is decorated with
+    `EventsCelery.event` decorator:
+
+    * it has same signature as initial function (T vs EventProtocol.__call__)
+    * it also has `name` and `app` attributes
+    * it has `handler` decorator which may bind and event handler to an event
+    """
+    name: str
+    app: "EventsCelery"
+
+    __call__: T
+
+    def handler(self, func: F) -> F: ...
+
+
+# noinspection PyTypeChecker
 class EventsCelery(Celery):
     task_cls = tasks.EventHandler
 
@@ -20,13 +41,29 @@ class EventsCelery(Celery):
         self.on_after_finalize.connect(self._register_retry_queues)
         self._handlers: Set[str] = set()
 
-    def event(self, name: str) -> Callable[[Callable], "Event"]:
-        def inner(func: Callable) -> Event:
-            return Event(self, name, func)
+    def event(self, name: str) -> Callable[[T], EventProtocol[T]]:
+        """
+        This decorator marks a callable as an event with name `name`
+        :param name: event name (also used as Celery task name)
+        :return: decorator that adds `name` attribute and `handler` method to
+            an event and also sends a message to the celery broker on decorated
+            function call.
+        """
+
+        def inner(func: T) -> EventProtocol[T]:
+            # noinspection PyTypeChecker
+            return cast(EventProtocol[T], Event(self, name, func))
 
         return inner
 
     def handler(self, name: str, bind: bool = False) -> Callable[[T], T]:
+        """
+        Decorates a function or a class as a handler for an event.
+        :param name: event name
+        :param bind: flag to pass Celery.Task instance to a function
+            (see `Celery.task(bind=True)`).
+        :return: a decorator with `name` and `bind` values set up.
+        """
 
         def inner(fun_or_cls: T) -> T:
             if name in self._handlers:
@@ -39,20 +76,45 @@ class EventsCelery(Celery):
 
     def _create_task_from_handler(self, fun_or_cls: T, *, name: str,
                                   bind: bool) -> T:
+        """
+        Registers a new task from class or function
+
+        :param fun_or_cls: event handler class or function
+        :param name: event name to stick handler to
+        :param bind: pass `self` argument to a function
+            (see `Celery.task(bind=True)`)
+        :returns fun_or_cls
+
+        """
         if isinstance(fun_or_cls, type) and issubclass(fun_or_cls, Task):
-            if self.Task in fun_or_cls.__bases__:
-                bases: Tuple[Type[Task], ...] = (fun_or_cls,)
-            else:
-                bases = (fun_or_cls, self.Task)
-            attrs = {'name': name}
-            new_name = getattr(fun_or_cls, '__name__')
-            task_class = type(new_name, bases, attrs)
-            self.register_task(task_class)
+            task_cls = self._make_task_cls(fun_or_cls, name)
+            self.tasks.register(task_cls)
         else:
             self.task(fun_or_cls, name=name, bind=bind)
         return fun_or_cls
 
+    def _make_task_cls(self, handler: Type[Task], name: str) -> Type[Task]:
+        """
+        Created a new class for a given class base.
+        
+        :param handler: handler class
+        :param name: event name
+        :return: new task class that inherits `task_class` and `self.Task`
+            and has `name` attribute set to event name
+        """
+        if self.Task in handler.__bases__:
+            bases: Tuple[Type[Task], ...] = (handler,)
+        else:
+            bases = (handler, self.Task)
+        attrs = {'name': name}
+        new_name = getattr(handler, '__name__')
+        # noinspection PyTypeChecker
+        return type(new_name, bases, attrs)
+
     def _generate_task_queues(self, **_: Any) -> None:
+        """
+        Create a list of queues for celery worker from registered handlers list.
+        """
         queues = self.conf.task_queues or []
         if queues:
             return
@@ -68,6 +130,9 @@ class EventsCelery(Celery):
         self.conf.task_queues = queues
 
     def _register_retry_queues(self, **_: Any) -> None:
+        """
+        Initializes a set of AMQP primitives to implement broker-based delays.
+        """
         channel = self.broker_connection().default_channel
         for queue in self.conf.task_queues:
             retry_queue = Queue(
@@ -98,6 +163,8 @@ class EventsCelery(Celery):
 
 
 class Event:
+    """ Event function wrapper that sends a message to broker"""
+
     def __init__(self, app: EventsCelery, name: str, func: Callable) -> None:
         self.app = app
         self.name = name
@@ -105,19 +172,15 @@ class Event:
 
     def __call__(self, *args: Any, **kwargs: Any) -> str:
         self.func(*args, **kwargs)
-        s = self.make_signature(args, kwargs)
-        result: AsyncResult = s.apply_async()
-        return result.id
-
-    def handler(self, func: Callable) -> Callable:
-        return self.app.handler(self.name)(func)
-
-    def make_signature(self, args: Tuple[Any, ...], kwargs: Dict[str, Any]
-                       ) -> Signature:
-        return Signature(
+        s = Signature(
             args=args,
             kwargs=kwargs,
             task=self.name,
             app=self.app,
             task_type=self.app.Task,
             routing_key=self.name)
+        result: AsyncResult = s.apply_async()
+        return result.id
+
+    def handler(self, func: Callable) -> Callable:
+        return self.app.handler(self.name)(func)

--- a/demo/tasks.py
+++ b/demo/tasks.py
@@ -1,16 +1,15 @@
-from celery import Task
-
+from celery.app.task import Task
 from demo import events
 from demo.celery import app
 
 
 @events.event_occured.handler
-def on_event_occured(value: str):
+def on_event_occured(value: str) -> None:
     print(f"event occured: {value}")
 
 
 @app.handler(events.number_is_odd.name, bind=True)
-def on_number_is_odd(self: Task, number: int):
+def on_number_is_odd(self: Task, number: int) -> None:
     if self.request.retries < 5:
         # retry task once
         raise ValueError(number)
@@ -20,5 +19,5 @@ def on_number_is_odd(self: Task, number: int):
 @app.handler(events.number_is_even.name)
 class NumberEvenHandler(Task):
     # noinspection PyMethodMayBeStatic
-    def run(self, number: int):
+    def run(self, number: int) -> None:
         print(f"number {number} is even")


### PR DESCRIPTION
When running MyPy static analysis on a project that uses `ampq_events`, it's useful to have proper event and handler function signatures, not only `Any`.